### PR TITLE
WIP: update to 0.11.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,19 +1,2 @@
-# cuda 9.2, gcc 7.3
-# cuda 10.0, gcc 7.3
-c_compiler_version:
-  - 7.3  # [linux64]
-  - 10   # [(osx and x86_64) or aarch64]
-  - 12   # [osx and arm64]
-cxx_compiler_version:
-  - 7.3  # [linux64]
-  - 10   # [(osx and x86_64) or aarch64]
-  - 12   # [osx and arm64]
-cudatoolkit:
-  - 10.0
-python:
-  - 3.7  # [not (osx and arm64)]
-  - 3.8
-  - 3.9
 pytorch_variant:
   - cpu
-# - gpu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.2" %}
+{% set version = "0.11.3" %}
 
 package:
   name: torchvision
@@ -7,11 +7,11 @@ package:
 source:
   fn: torchvision-{{ version }}.tar.gz
   url: https://github.com/pytorch/vision/archive/v{{ version }}.tar.gz
-  sha256: 9a866c3c8feb23b3221ce261e6153fc65a98ce9ceaa71ccad017016945c178bf
+  sha256: b4c51d27589783e6e6941ecaa67b55f6f41633874ec37f80b64a0c92c3196e0c
 
 build:
   number: 0
-  skip: True  # [not (osx or linux64 or aarch64)]
+  skip: True  # [py<36 or py>39]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
   script:
@@ -36,24 +36,23 @@ requirements:
     - cudatoolkit {{ cudatoolkit }}*  # [pytorch_variant == "gpu"]
     # other requirements
     - python
-    - pip
     - setuptools
-    - jpeg
-    - libpng
-    - pytorch 1.7.1  # [linux and not (s390x or aarch64)]
-    - pytorch 1.8.1  # [linux and (s390x or aarch64)]
+    - pip
+    - pytorch ==1.10.2
+    - pillow >=5.3.0,!=8.3.*
+    # - ffmpeg
   run:
-    - _pytorch_select ==0.1             # [pytorch_variant == "cpu"]
-    - _pytorch_select ==0.2             # [pytorch_variant == "gpu"]
+    # - _pytorch_select * cpu*             # [pytorch_variant == "cpu"]
+    # - _pytorch_select * gpu*             # [pytorch_variant == "gpu"]
     # GPU requirements
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [pytorch_variant == "gpu"]
     # other requirements
     - python
-    - pillow >=4.1.1
-    - numpy >=1.11
-    - pytorch 1.7.1  # [linux and not (s390x or aarch64)]
-    - pytorch 1.8.1  # [linux and (s390x or aarch64)]
-    - six
+    - setuptools
+    - pip
+    - pytorch ==1.10.2
+    - pillow >=5.3.0,!=8.3.*
+    # - ffmpeg
 
 test:
   imports:
@@ -66,8 +65,8 @@ test:
     - test
   requires:
     - pytest
+    - pytest-mock
     - scipy
-    - mock  # [linux]
     - requests
   commands:
     pytest . -k "not (video or test_url_is_accessible)"  # [osx]


### PR DESCRIPTION
The initial local builds here are looking fine, but there are quite a few test failures.

Some of them are due to the absence of `av` from our repository, which is a package used in the test phase only. Because it is a test package only perhaps we could pull it from conda-forge. Otherwise it would have to be built or those tests skipped.

The others seem to be failing for other reasons. But note that even the conda-forge recipe skips tests so I'm not convinced this ought to be fatal.