### PR TITLE
Rebuild torchvision 0.11.3 b1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0001-avoid-hard-coded-gcc.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<36 or py>39 or s390x or ppc64le]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
@@ -105,9 +105,8 @@ test:
     # For pkg_resources
     - setuptools
   commands:
-    # scipy 1.7.3 has requirement numpy<1.23.0,>=1.16.5, but you have numpy 1.23.1.
-    - python -m pip check || true    # [not win]
-    #- python -m pip check || exit 1  # [win]
+    - python -m pip check || true      # [not win]
+    - python -m pip check || (exit 1)  # [win]
     # CIs do not have enough resources to run the full suite of model tests
     - rm -f test/test_models.py      # [unix]
     - del /f test\test_models.py     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 1
-  skip: True  # [py<36 or py>39 or s390x or ppc64le]
+  skip: True  # [py<36 or s390x or ppc64le]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
   script:
@@ -119,9 +119,11 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
+  license_url: https://github.com/pytorch/vision/blob/main/LICENSE
   summary: Image and video datasets and models for torch deep learning
   dev_url: https://github.com/pytorch/vision
   doc_url: https://pytorch.org/docs/stable/index.html
+  doc_source_url: https://github.com/pytorch/vision/tree/main/docs/source
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Actions:
1. Bump build number
2. [py-opencv](https://github.com/AnacondaRecipes/opencv-feedstock/pull/23) has `python 3.10` and `linux-aarch64` support now: so we do not need to skip `py>39`. 
3. Uncomment & fix `pip check`: the issue of `scipy` was resolved, see https://github.com/AnacondaRecipes/scipy-feedstock/pull/19