### PR TITLE
Remove sysroot_linux-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0001-avoid-hard-coded-gcc.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [py<36 or s390x or ppc64le]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
@@ -45,7 +45,6 @@ requirements:
     - libpng
     - m2-patch  # [win]
     - patch     # [not win]
-    - sysroot_linux-64 ==2.17         # [linux64]
   host:
     # GPU requirements
     - cudatoolkit {{ cudatoolkit }}*  # [pytorch_variant == "gpu"]


### PR DESCRIPTION
`sysroot_linux-64 ==2.17  # [linux64]` causes an incompatibility issue if you try to build downstream packages, for example, `easyocr` https://github.com/AnacondaRecipes/easyocr-feedstock/pull/1

==== Example ====
`linux-64`:
`CONDA_SUBDIR=linux-64 conda create -n test_env --dry-run python=3.9 pip setuptools wheel ninja numpy pillow py-opencv pyclipper python-bidi pyyaml scikit-image scipy shapely pytorch torchvision -vvv 2>&1 | grep -e "-> 0"`:
```
DEBUG conda.resolve:filter_group(636): torchvision: pruned from 7 -> 0
DEBUG conda.resolve:filter_group(636): opencv: pruned from 30 -> 0
DEBUG conda.resolve:filter_group(636): py-opencv: pruned from 3 -> 0
```

With enabling `experimental_solver: libmamba` in `.condarc`:
`linux-64`:
```
conda_libmamba_solver.exceptions.LibMambaUnsatisfiableError: Encountered problems while solving:
  - nothing provides __glibc >=2.17,<3.0.a0 needed by qtwebkit-5.212-h4eab89a_4
  - nothing provides __glibc >=2.17,<3.0.a0 needed by qtwebkit-5.212-h4eab89a_4
We can see that __glibc >=2.17,<3.0.a0 is needed by qtwebkit
```