### PR TITLE
rebuild or update for missing platforms

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
     - LDFLAGS="${LDFLAGS//-Wl,-z,now/-Wl,-z,lazy}"    # [not win]
     - set "TORCHVISION_INCLUDE=%LIBRARY_INC%"         # [win]
     - export TORCHVISION_INCLUDE="${PREFIX}/include"  # [not win]
-    - "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation"
+    - "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
   missing_dso_whitelist:
     - "$RPATH/libc10.so"           # [linux]
     - "$RPATH/libc10.dylib"        # [osx]
@@ -74,8 +74,6 @@ requirements:
 # 2022/08/30: Skipping the av tests (they require module 'av'): ModuleNotFoundError: No module named 'av',
 # because the av package depends on ffmpeg, which we are not requiring as a run requirement because torchvision has bugs with certain ffmpeg versions.
 {% set tests_to_skip = tests_to_skip + " or test_classes or test_feature_types or test_feature_types or test_is_valid_file or test_num_examples or test_smoke or test_str_smoke or test_transforms" %}
-# 2022/08/30: AssertionError: Tensor-likes are not equal!
-#{% set tests_to_skip = tests_to_skip + " or test_adjust_gamma" %}
 # 2022/08/30: This test seems to just destroy the memory of the system.
 # they actually run on most platform except but were still hanging on linux-aarch64 and osx-arm64
 {% set tests_to_skip = tests_to_skip + " or test_forward_backward" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37 or s390x or ppc64le]
+  skip: True  # [py<37 or s390x]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
   script:
@@ -64,8 +64,7 @@ requirements:
     - python
     # Numpy pinnings aligned with the pytorch recipe,
     # see https://github.com/AnacondaRecipes/pytorch-feedstock/blob/ab185825c85cce2761ada2fc519b986845ddeb7d/recipe/meta.yaml#L121
-    - numpy >=1.21.2,<2.0a0 # [py>=310]
-    - numpy >=1.19.2,<2.0a0 # [py<=39]
+    - numpy {{ numpy }}
     - pillow >=5.3.0,!=8.3.*
     - pytorch
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,6 +105,10 @@ test:
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
     - cp -r $SRC_DIR/../work_moved_torchvision-*/references .  # [not win]
+    - dir %SRC_DIR%  # [win]
+    - dir %SRC_DIR%\..  # [win]
+    - dir %SRC_DIR%\..\work  # [win]
+    - dir %SRC_DIR%\..\work_moved_torchvision-*  # [win]
     - xcopy %SRC_DIR%\..\work_moved_torchvision-*\references %SRC_DIR% /E/H  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - pytorch 2.0.1
     # libpng and libjpeg must be available at compilation time
     - jpeg 9e  # [not win]
-    - libpng 1.6.39
+    - libpng {{ libpng }}
     # GPU requirements
     - cudatoolkit {{ cudatoolkit }}  # [pytorch_variant == "gpu"]
     # 2022/08/25: Not requiring ffmpeg because torchvision has bugs with certain ffmpeg versions, 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,12 +45,10 @@ requirements:
     - cudatoolkit {{ cudatoolkit }}  # [pytorch_variant == "gpu"]
     # other requirements
     - python
-    - jpeg      # [not win]
-    - libpng
+    - jpeg 9e  # [not win]
+    - libpng 1.6.39
     - pip
     - pillow 9.4.0
-    # exact pytorch pinning is due to the fact that naming of source files used to build torchvisions have changed over
-    # the course of pytorch releases
     - pytorch 2.0.1
     - wheel
     # 2022/08/25: Not requiring ffmpeg because torchvision has bugs with certain ffmpeg versions, 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -120,10 +120,9 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: This library is part of the PyTorch project. PyTorch is an open source machine learning framework.
+  summary: Image and video datasets and models for torch deep learning
   description: |
     The torchvision package consists of popular datasets, model architectures, and common image transformations for computer vision.
-  summary: Image and video datasets and models for torch deep learning
   dev_url: https://github.com/pytorch/vision
   doc_url: https://pytorch.org/docs/stable/index.html
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,7 +102,7 @@ test:
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
     - cp -r ../work_moved_torchvision-{{ version }}-{{ pytorch_variant }}_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}_*/references .  # [not win]
-    - xcopy ..\work_moved_torchvision-{{ version }}-{{ pytorch_variant }}_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}_*\references . /E /H /C /I  # [win]
+    - xcopy /E /H /C /I ..\work_moved_torchvision-{{ version }}-*\references .  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,6 +107,9 @@ test:
     # CIs do not have enough resources to run the full suite of model tests
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
+    # Test failing because of missing file (to be clarified)
+    - rm -f test/test_transforms_v2_consistency.py   # [not win]
+    - del /f test\test_transforms_v2_consistency.py  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,9 +103,11 @@ test:
     # CIs do not have enough resources to run the full suite of model tests
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
-    - cp -r $SRC_DIR/references .  # [not win]
+    - echo PREFIX $PREFIX PATH $PATH STDLIB_DIR $STDLIB_DIR SRC_DIR $SRC_DIR SP_DIR $SP_DIR
+    - echo $(pwd)  # [not win]
+    - cp -r $PREFIX/references .  # [not win]
     - CD  # [win]
-    - COPY  $SRC_DIR\references .  # [win]
+    - COPY  $PREFIX\references .  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   skip: True  # [py<37 or s390x or ppc64le]
-  skip: True  # [not win]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
   script:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.13.1" %}
+{% set version = "0.15.2" %}
 
 package:
   name: torchvision
@@ -7,7 +7,7 @@ package:
 source:
   fn: torchvision-{{ version }}.tar.gz
   url: https://github.com/pytorch/vision/archive/v{{ version }}.tar.gz
-  sha256: c32fab734e62c7744dadeb82f7510ff58cc3bca1189d17b16aa99b08afc42249
+  sha256: 1efcb80e0a6e42c54f07ee16167839b4d302aeeecc12839cc47c74b06a2c20d4
 
 build:
   number: 0
@@ -21,7 +21,7 @@ build:
     - LDFLAGS="${LDFLAGS//-Wl,-z,now/-Wl,-z,lazy}"    # [not win]
     - set "TORCHVISION_INCLUDE=%LIBRARY_INC%"         # [win]
     - export TORCHVISION_INCLUDE="${PREFIX}/include"  # [not win]
-    - "{{ PYTHON }} -m pip install . -vv"
+    - "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation"
   missing_dso_whitelist:
     - "$RPATH/libc10.so"           # [linux]
     - "$RPATH/libc10.dylib"        # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,9 +105,9 @@ test:
     - del /f test\test_models.py test\test_extended_models.py    # [win]
     - echo PREFIX $PREFIX PATH $PATH STDLIB_DIR $STDLIB_DIR SRC_DIR $SRC_DIR SP_DIR $SP_DIR
     - echo $(pwd)  # [not win]
-    - cp -r $PREFIX/references .  # [not win]
+    - cp -r $SRC_DIR/../work_moved_torchvision-*/references .  # [not win]
     - CD  # [win]
-    - COPY  $PREFIX\references .  # [win]
+    - COPY  $SRC_DIR\..\work_moved_torchvision-*\references .  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,8 +78,9 @@ requirements:
 # 2022/08/30: AssertionError: Tensor-likes are not equal!
 {% set tests_to_skip = tests_to_skip + " or test_adjust_gamma" %}
 # 2022/08/30: This test seems to just destroy the memory of the system.
-{% set tests_to_skip = tests_to_skip + " or test_forward_backward" %}  # [not ((linux and aarch64) or (osx and arm64))]
-{% set tests_to_skip = tests_to_skip + " or test_jit_forward_backward" %}  # [not ((linux and aarch64) or (osx and arm64))]
+# they actually run on most platform except but were still hanging on linux-aarch64 and osx-arm64
+{% set tests_to_skip = tests_to_skip + " or test_forward_backward" %}
+{% set tests_to_skip = tests_to_skip + " or test_jit_forward_backward" %}
 # 2023/07/06: CIs do not have enough resources to run the full suite of model tests
 # test_extended_models
 {% set tests_to_skip = tests_to_skip + " or test_get_model or test_get_model_builder or test_get_model_weights" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,8 @@ requirements:
     - cudatoolkit {{ cudatoolkit }}  # [pytorch_variant == "gpu"]
     # other requirements
     - python
+    - jpeg 9e  # [not win]
+    - libpng 1.6.39
     - pip
     - pytorch 2.0.1
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<37 or s390x or ppc64le]
+  skip: True  # [not win]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
   script:
@@ -104,7 +105,7 @@ test:
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
     - cp -r ../work_moved_torchvision-{{ version }}-{{ pytorch_variant }}_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}_*/references .  # [not win]
-    - Xcopy.exe /E /H /C ..\work_moved_torchvision-{{ version }}-*\references .  # [win]
+    - COPY /E /H /C ..\work_moved_torchvision-{{ version }}-*\references .  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: torchvision-{{ version }}.tar.gz
   url: https://github.com/pytorch/vision/archive/v{{ version }}.tar.gz
   sha256: 1efcb80e0a6e42c54f07ee16167839b4d302aeeecc12839cc47c74b06a2c20d4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<37 or s390x or ppc64le]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
   script:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,6 +87,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_multi_params or test_default_callable or test_pretrained_deprecation" %}
 # test_models
 {% set tests_to_skip = tests_to_skip + " or test_detection_model" %}
+{% set tests_to_skip = tests_to_skip + " or test_quantized_classification_model" %}  # [linux]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -133,3 +133,5 @@ extra:
     - katietz
     - jjhelmus
     - nehaljwani
+  skip-lints:
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,10 +45,7 @@ requirements:
     - cudatoolkit {{ cudatoolkit }}  # [pytorch_variant == "gpu"]
     # other requirements
     - python
-    - jpeg 9e  # [not win]
-    - libpng 1.6.39
     - pip
-    - pillow 9.4.0
     - pytorch 2.0.1
     - wheel
     # 2022/08/25: Not requiring ffmpeg because torchvision has bugs with certain ffmpeg versions, 
@@ -56,21 +53,16 @@ requirements:
     # and https://github.com/conda-forge/torchvision-feedstock/commit/4ec4b5f4eb4889dbb1f8da34662ea622bb4b3828
     # - ffmpeg
   run:
-    # - _pytorch_select * cpu*             # [pytorch_variant == "cpu"]
-    # - _pytorch_select * gpu*             # [pytorch_variant == "gpu"]
     # GPU requirements
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [pytorch_variant == "gpu"]
-    # other requirements
-    - python
-    # Numpy pinnings aligned with the pytorch recipe,
-    # see https://github.com/AnacondaRecipes/pytorch-feedstock/blob/ab185825c85cce2761ada2fc519b986845ddeb7d/recipe/meta.yaml#L121
     - numpy {{ numpy }}
     - pillow >=5.3.0,!=8.3.*
     - pytorch
     - requests
+    - jpeg  # [not win]
+    - libpng
     - setuptools
     # - ffmpeg
-    - typing_extensions
 
 # Skip test_url_is_accessible instead of hitting 20+ servers per run, since
 # each server might be occasionally unresponsive and end up failing our CI

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,6 +80,8 @@ requirements:
 # 2022/08/30: This test seems to just destroy the memory of the system.
 {% set tests_to_skip = tests_to_skip + " or test_forward_backward" %}
 {% set tests_to_skip = tests_to_skip + " or test_jit_forward_backward" %}
+# 2023/07/06: CIs do not have enough resources to run the full suite of model tests
+{% set tests_to_skip = tests_to_skip + " or test_get_model or test_get_model_builder or test_get_model_weights or test_weights_copyable or test_weights_deserializable or test_list_models or test_get_weight or test_naming_conventions or test_schema_meta_validation or test_transforms_jit or test_no_warn or test_pretrained_pos or test_pretrained_kw or test_equivalent_behavior_weights or test_multi_params or test_default_callable or test_pretrained_deprecation" %}
 
 test:
   imports:
@@ -101,8 +103,6 @@ test:
   commands:
     - pip check || true      # [not win]
     - pip check || (exit 1)  # [win]
-    # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
-    #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]
     - pytest -v -k "not ({{ tests_to_skip }} or test_frozenbatchnorm2d_eps)" test/  # [linux and aarch64]
     - pytest -v -k "not ({{ tests_to_skip }} or test_maskrcnn_resnet50_fpn_cpu)" test/  # [linux and (not aarch64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ requirements:
   run:
     # GPU requirements
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [pytorch_variant == "gpu"]
-    - numpy {{ numpy }}
+    - {{ pin_compatible('numpy') }}
     - pillow >=5.3.0,!=8.3.*
     - pytorch
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - jpeg      # [not win]
     - libpng
     - pip
-    - pillow >=5.3.0,!=8.3.*
+    - pillow 9.4.0
     - pytorch
     - wheel
     # 2022/08/25: Not requiring ffmpeg because torchvision has bugs with certain ffmpeg versions, 
@@ -120,7 +120,9 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  license_url: https://github.com/pytorch/vision/blob/main/LICENSE
+  summary: This library is part of the PyTorch project. PyTorch is an open source machine learning framework.
+  description: |
+    The torchvision package consists of popular datasets, model architectures, and common image transformations for computer vision.
   summary: Image and video datasets and models for torch deep learning
   dev_url: https://github.com/pytorch/vision
   doc_url: https://pytorch.org/docs/stable/index.html

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,11 +77,15 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_classes or test_feature_types or test_feature_types or test_is_valid_file or test_num_examples or test_smoke or test_str_smoke or test_transforms" %}
 # 2022/08/30: AssertionError: Tensor-likes are not equal!
 {% set tests_to_skip = tests_to_skip + " or test_adjust_gamma" %}
+# 2022/08/30: This test seems to just destroy the memory of the system.
+{% set tests_to_skip = tests_to_skip + " or test_forward_backward" %}  # [not ((linux and aarch64) or (osx and arm64))]
+{% set tests_to_skip = tests_to_skip + " or test_jit_forward_backward" %}  # [not ((linux and aarch64) or (osx and arm64))]
 # 2023/07/06: CIs do not have enough resources to run the full suite of model tests
 # test_extended_models
 {% set tests_to_skip = tests_to_skip + " or test_get_model or test_get_model_builder or test_get_model_weights" %}
 {% set tests_to_skip = tests_to_skip + " or test_weights_copyable or test_weights_deserializable or test_list_models" %}
 {% set tests_to_skip = tests_to_skip + " or test_get_weight or test_naming_conventions or test_schema_meta_validation" %}
+# from now on something surely needs to be disabled
 {% set tests_to_skip = tests_to_skip + " or test_transforms_jit or test_no_warn or test_pretrained_pos" %}
 {% set tests_to_skip = tests_to_skip + " or test_pretrained_kw or test_equivalent_behavior_weights" %}
 {% set tests_to_skip = tests_to_skip + " or test_multi_params or test_default_callable or test_pretrained_deprecation" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,7 @@ requirements:
 # because the av package depends on ffmpeg, which we are not requiring as a run requirement because torchvision has bugs with certain ffmpeg versions.
 {% set tests_to_skip = tests_to_skip + " or test_classes or test_feature_types or test_feature_types or test_is_valid_file or test_num_examples or test_smoke or test_str_smoke or test_transforms" %}
 # 2022/08/30: AssertionError: Tensor-likes are not equal!
-{% set tests_to_skip = tests_to_skip + " or test_adjust_gamma" %}
+#{% set tests_to_skip = tests_to_skip + " or test_adjust_gamma" %}
 # 2022/08/30: This test seems to just destroy the memory of the system.
 # they actually run on most platform except but were still hanging on linux-aarch64 and osx-arm64
 {% set tests_to_skip = tests_to_skip + " or test_forward_backward" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,15 +41,15 @@ requirements:
     - jpeg      # [not win]
     - libpng
   host:
-    # GPU requirements
-    - cudatoolkit {{ cudatoolkit }}  # [pytorch_variant == "gpu"]
-    # other requirements
     - python
+    - pip
+    - wheel
+    - pytorch 2.0.1
+    # libpng and libjpeg must be available at compilation time
     - jpeg 9e  # [not win]
     - libpng 1.6.39
-    - pip
-    - pytorch 2.0.1
-    - wheel
+    # GPU requirements
+    - cudatoolkit {{ cudatoolkit }}  # [pytorch_variant == "gpu"]
     # 2022/08/25: Not requiring ffmpeg because torchvision has bugs with certain ffmpeg versions, 
     # see https://github.com/pytorch/vision/issues/5419#issuecomment-1193483864
     # and https://github.com/conda-forge/torchvision-feedstock/commit/4ec4b5f4eb4889dbb1f8da34662ea622bb4b3828

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<37 or s390x or ppc64le]
+  skip: True  # [not win]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
   script:
@@ -104,7 +105,7 @@ test:
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
     - cp -r ../work_moved_torchvision-{{ version }}-{{ pytorch_variant }}_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}_*/references .  # [not win]
-    - xcopy /E /H /C /I ..\work_moved_torchvision-{{ version }}-*\references .  # [win]
+    - Xcopy.exe /E /H /C ..\work_moved_torchvision-{{ version }}-*\references .  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ requirements:
     - numpy {{ numpy }}
     - pytorch 2.0.1
     # libpng and libjpeg must be available at compilation time
-    - jpeg 9e  # [not win]
+    - jpeg {{ jpeg }}  # [not win]
     - libpng {{ libpng }}
     # GPU requirements
     - cudatoolkit {{ cudatoolkit }}  # [pytorch_variant == "gpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -108,7 +108,7 @@ test:
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
     - cp -r ../work_moved_torchvision-{{ version }}-{{ pytorch_variant }}_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}_*/references .  # [not win]
-    - xcopy ../work_moved_torchvision-{{ version }}-{{ pytorch_variant }}_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}_*/references . /E /H /C /I  # [win]
+    - xcopy ..\work_moved_torchvision-{{ version }}-{{ pytorch_variant }}_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}_*\references . /E /H /C /I  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,11 +77,16 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_classes or test_feature_types or test_feature_types or test_is_valid_file or test_num_examples or test_smoke or test_str_smoke or test_transforms" %}
 # 2022/08/30: AssertionError: Tensor-likes are not equal!
 {% set tests_to_skip = tests_to_skip + " or test_adjust_gamma" %}
-# 2022/08/30: This test seems to just destroy the memory of the system.
-{% set tests_to_skip = tests_to_skip + " or test_forward_backward" %}
-{% set tests_to_skip = tests_to_skip + " or test_jit_forward_backward" %}
 # 2023/07/06: CIs do not have enough resources to run the full suite of model tests
-{% set tests_to_skip = tests_to_skip + " or test_get_model or test_get_model_builder or test_get_model_weights or test_weights_copyable or test_weights_deserializable or test_list_models or test_get_weight or test_naming_conventions or test_schema_meta_validation or test_transforms_jit or test_no_warn or test_pretrained_pos or test_pretrained_kw or test_equivalent_behavior_weights or test_multi_params or test_default_callable or test_pretrained_deprecation" %}
+# test_extended_models
+{% set tests_to_skip = tests_to_skip + " or test_get_model or test_get_model_builder or test_get_model_weights" %}
+{% set tests_to_skip = tests_to_skip + " or test_weights_copyable or test_weights_deserializable or test_list_models" %}
+{% set tests_to_skip = tests_to_skip + " or test_get_weight or test_naming_conventions or test_schema_meta_validation" %}
+{% set tests_to_skip = tests_to_skip + " or test_transforms_jit or test_no_warn or test_pretrained_pos" %}
+{% set tests_to_skip = tests_to_skip + " or test_pretrained_kw or test_equivalent_behavior_weights" %}
+{% set tests_to_skip = tests_to_skip + " or test_multi_params or test_default_callable or test_pretrained_deprecation" %}
+# test_models
+{% set tests_to_skip = tests_to_skip + " or test_detection_model" %}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - libpng
   host:
     # GPU requirements
-    - cudatoolkit {{ cudatoolkit }}*  # [pytorch_variant == "gpu"]
+    - cudatoolkit {{ cudatoolkit }}  # [pytorch_variant == "gpu"]
     # other requirements
     - python
     - jpeg      # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,9 @@ requirements:
     - libpng
     - pip
     - pillow 9.4.0
-    - pytorch
+    # exact pytorch pinning is due to the fact that naming of source files used to build torchvisions have changed over
+    # the course of pytorch releases
+    - pytorch 2.0.1
     - wheel
     # 2022/08/25: Not requiring ffmpeg because torchvision has bugs with certain ffmpeg versions, 
     # see https://github.com/pytorch/vision/issues/5419#issuecomment-1193483864

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,6 +90,7 @@ test:
     - torchvision.utils
   source_files:
     - test
+    - references
   requires:
     - pip
     - pytest
@@ -103,12 +104,6 @@ test:
     # CIs do not have enough resources to run the full suite of model tests
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
-    - cp -r $SRC_DIR/../work_moved_torchvision-*/references .  # [not win]
-    - dir %SRC_DIR%  # [win]
-    - dir %SRC_DIR%\..  # [win]
-    - dir %SRC_DIR%\..\work  # [win]
-    - dir %SRC_DIR%\..\work_moved_torchvision-*  # [win]
-    - xcopy %SRC_DIR%\..\work_moved_torchvision-*\references %SRC_DIR% /E/H  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ requirements:
     - python
     - pip
     - wheel
+    - numpy {{ numpy }}
     - pytorch 2.0.1
     # libpng and libjpeg must be available at compilation time
     - jpeg 9e  # [not win]
@@ -58,6 +59,7 @@ requirements:
     # GPU requirements
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [pytorch_variant == "gpu"]
     - {{ pin_compatible('numpy') }}
+    - python
     - pillow >=5.3.0,!=8.3.*
     - pytorch
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<37 or s390x or ppc64le]
+  skip: True  # [not win]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
   script:
@@ -103,12 +104,8 @@ test:
     # CIs do not have enough resources to run the full suite of model tests
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
-    - echo PREFIX $PREFIX PATH $PATH STDLIB_DIR $STDLIB_DIR SRC_DIR $SRC_DIR SP_DIR $SP_DIR
-    - echo $(pwd)  # [not win]
     - cp -r $SRC_DIR/../work_moved_torchvision-*/references .  # [not win]
-    - ECHO echo  # [win]
-    - CD  # [win]
-    - xcopy $SRC_DIR\..\work_moved_torchvision-*\references /E/H .  # [win]
+    - xcopy %SRC_DIR%\..\work_moved_torchvision-*\references %SRC_DIR% /E/H  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   skip: True  # [py<37 or s390x or ppc64le]
-  skip: True  # [not win]
   string: cuda{{ cudatoolkit | replace('.', '') }}py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}  # [pytorch_variant == "gpu"]
   string: cpu_py{{ CONDA_PY }}h{{PKG_HASH}}_{{ PKG_BUILDNUM }}                                      # [pytorch_variant == "cpu"]
   script:
@@ -104,8 +103,9 @@ test:
     # CIs do not have enough resources to run the full suite of model tests
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
-    - cp -r ../work_moved_torchvision-{{ version }}-{{ pytorch_variant }}_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}_*/references .  # [not win]
-    - COPY /E /H /C ..\work_moved_torchvision-{{ version }}-*\references .  # [win]
+    - cp -r $SRC_DIR/references .  # [not win]
+    - CD  # [win]
+    - COPY  $SRC_DIR\references .  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,9 +107,8 @@ test:
     # CIs do not have enough resources to run the full suite of model tests
     - rm -f test/test_models.py test/test_extended_models.py     # [not win]
     - del /f test\test_models.py test\test_extended_models.py    # [win]
-    # Test failing because of missing file (to be clarified)
-    - rm -f test/test_transforms_v2_consistency.py   # [not win]
-    - del /f test\test_transforms_v2_consistency.py  # [win]
+    - cp -r ../work_moved_torchvision-{{ version }}-{{ pytorch_variant }}_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}_*/references .  # [not win]
+    - xcopy ../work_moved_torchvision-{{ version }}-{{ pytorch_variant }}_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}_*/references . /E /H /C /I  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,8 +106,9 @@ test:
     - echo PREFIX $PREFIX PATH $PATH STDLIB_DIR $STDLIB_DIR SRC_DIR $SRC_DIR SP_DIR $SP_DIR
     - echo $(pwd)  # [not win]
     - cp -r $SRC_DIR/../work_moved_torchvision-*/references .  # [not win]
+    - ECHO echo  # [win]
     - CD  # [win]
-    - COPY  $SRC_DIR\..\work_moved_torchvision-*\references .  # [win]
+    - xcopy $SRC_DIR\..\work_moved_torchvision-*\references /E/H .  # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,9 +101,6 @@ test:
   commands:
     - pip check || true      # [not win]
     - pip check || (exit 1)  # [win]
-    # CIs do not have enough resources to run the full suite of model tests
-    - rm -f test/test_models.py test/test_extended_models.py     # [not win]
-    - del /f test\test_models.py test\test_extended_models.py    # [win]
     # 2022/12/5: Unexpected python error on osx-64 for python 3.10: `Abort trap: 6 pytest test/`
     #- pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and x86_64) and py<310]
     - pytest -v -k "not ({{ tests_to_skip }})" test/  # [(osx and arm64)]


### PR DESCRIPTION
* updating to have dependents of `torchvision` build for python 3.11.
* this is instrumental for building [sentences-transformers:PR5](https://github.com/AnacondaRecipes/sentence-transformers-feedstock/pull/5)