### PR TITLE
torchvision 0.22.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -4,4 +4,4 @@ extra_labels_for_os:
   osx-arm64: [ventura]
 
 channels:
-  - jrobertson
+  - pytlin272/label/pytorch

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,4 +4,4 @@ extra_labels_for_os:
   osx-arm64: [ventura]
 
 channels:
-  - https://staging.continuum.io/pbp/fs/pytorch-feedstock/pr83/5ddb6f9
+  - jrobertson

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,4 +4,4 @@ extra_labels_for_os:
   osx-arm64: [ventura]
 
 channels:
-  - https://staging.continuum.io/pbp/fs/pytorch-feedstock/pr82/dd1d0d9
+  - jrobertson

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-# macOS 12.3 or above is required for running the GPU variant (MPS support). No way to specify this for only the GPU
-# variant, so it's specified for both.
-extra_labels_for_os:
-  osx-arm64: [ventura]

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,3 @@
 # variant, so it's specified for both.
 extra_labels_for_os:
   osx-arm64: [ventura]
-
-channels:
-  - pytlin272/label/pytorch

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,3 @@
 # variant, so it's specified for both.
 extra_labels_for_os:
   osx-arm64: [ventura]
-
-channels:
-  - jrobertson

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,4 +4,4 @@ extra_labels_for_os:
   osx-arm64: [ventura]
 
 channels:
-  - https://staging.continuum.io/pbp/fs/pytorch-feedstock/pr82/a1baab6
+  - https://staging.continuum.io/pbp/fs/pytorch-feedstock/pr82/dd1d0d9

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,6 @@
 # variant, so it's specified for both.
 extra_labels_for_os:
   osx-arm64: [ventura]
+
+channels:
+  - jrobertson

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,4 +4,4 @@ extra_labels_for_os:
   osx-arm64: [ventura]
 
 channels:
-  - jrobertson
+  - https://staging.continuum.io/pbp/fs/pytorch-feedstock/pr83/a70e73c

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,6 @@
 # variant, so it's specified for both.
 extra_labels_for_os:
   osx-arm64: [ventura]
+
+channels:
+  - https://staging.continuum.io/pbp/fs/pytorch-feedstock/pr82/a1baab6

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,4 +4,4 @@ extra_labels_for_os:
   osx-arm64: [ventura]
 
 channels:
-  - https://staging.continuum.io/pbp/fs/pytorch-feedstock/pr83/a70e73c
+  - https://staging.continuum.io/pbp/fs/pytorch-feedstock/pr83/5ddb6f9

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,15 +4,14 @@ if [[ "${gpu_variant}" != "cuda" ]]; then
   export FORCE_CUDA=0
 else
   if [[ ${cuda_compiler_version} == 12.[0-6] ]]; then
-      export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0"
+      export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
       # $CUDA_HOME not set in CUDA 12.0. Using $PREFIX
       export CUDA_TOOLKIT_ROOT_DIR="${PREFIX}"
   else
-      echo "unsupported cuda version. edit build.sh"
-      exit 1
+      # nvcc 12.8 and later should be exporting TORCH_CUDA_ARCH_LIST
+      echo "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
   fi
-  # Add PTX at the end, always
-  export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}+PTX"
+
   export FORCE_CUDA=1
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,7 @@ set -ex
 if [[ "${gpu_variant}" != "cuda" ]]; then
   export FORCE_CUDA=0
 else
-  export CUDA_HOME="${PREFIX}"
+  export CUDA_HOME="${BUILD_PREFIX}"
   export FORCE_CUDA=1
   echo "DEBUG: CUDA_HOME=${CUDA_HOME}"
   echo "DEBUG: Checking if CUDA_HOME exists: $(ls -la ${CUDA_HOME}/bin/nvcc 2>&1 || echo 'nvcc not found')"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,11 +3,7 @@ set -ex
 if [[ "${gpu_variant}" != "cuda" ]]; then
   export FORCE_CUDA=0
 else
-  export CUDA_HOME="${BUILD_PREFIX}"
-  export FORCE_CUDA=1
-  echo "DEBUG: CUDA_HOME=${CUDA_HOME}"
-  echo "DEBUG: Checking if CUDA_HOME exists: $(ls -la ${CUDA_HOME}/bin/nvcc 2>&1 || echo 'nvcc not found')"
-  if [[ ${cuda_compiler_version} == 12.[0-8] ]]; then
+  if [[ ${cuda_compiler_version} == 12.[0-6] ]]; then
       export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
       # $CUDA_HOME not set in CUDA 12.0. Using $PREFIX
       export CUDA_TOOLKIT_ROOT_DIR="${PREFIX}"
@@ -15,6 +11,8 @@ else
       # nvcc 12.8 and later should be exporting TORCH_CUDA_ARCH_LIST
       echo "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
   fi
+
+  export FORCE_CUDA=1
 fi
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" == "1" ]]; then
@@ -37,4 +35,4 @@ export TORCHVISION_USE_NVJPEG=${FORCE_CUDA}
 
 
 export TORCHVISION_INCLUDE="${PREFIX}/include/"
-${PYTHON} setup.py install --single-version-externally-managed --record=record.txt
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,7 @@ set -ex
 if [[ "${gpu_variant}" != "cuda" ]]; then
   export FORCE_CUDA=0
 else
-  if [[ ${cuda_compiler_version} == 12.[0-6] ]]; then
+  if [[ ${cuda_compiler_version} == 12.[0-8] ]]; then
       export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
       # $CUDA_HOME not set in CUDA 12.0. Using $PREFIX
       export CUDA_TOOLKIT_ROOT_DIR="${PREFIX}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,10 @@ set -ex
 if [[ "${gpu_variant}" != "cuda" ]]; then
   export FORCE_CUDA=0
 else
+  export CUDA_HOME="${PREFIX}"
+  export FORCE_CUDA=1
+  echo "DEBUG: CUDA_HOME=${CUDA_HOME}"
+  echo "DEBUG: Checking if CUDA_HOME exists: $(ls -la ${CUDA_HOME}/bin/nvcc 2>&1 || echo 'nvcc not found')"
   if [[ ${cuda_compiler_version} == 12.[0-8] ]]; then
       export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
       # $CUDA_HOME not set in CUDA 12.0. Using $PREFIX
@@ -11,9 +15,6 @@ else
       # nvcc 12.8 and later should be exporting TORCH_CUDA_ARCH_LIST
       echo "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
   fi
-
-  export CUDA_HOME="${PREFIX}"
-  export FORCE_CUDA=1
 fi
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" == "1" ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,4 +37,4 @@ export TORCHVISION_USE_NVJPEG=${FORCE_CUDA}
 
 
 export TORCHVISION_INCLUDE="${PREFIX}/include/"
-${PYTHON} -m pip install . -vv --no-deps --no-build-isolation
+${PYTHON} setup.py install --single-version-externally-managed --record=record.txt

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,6 +12,7 @@ else
       echo "TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
   fi
 
+  export CUDA_HOME="${PREFIX}"
   export FORCE_CUDA=1
 fi
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,11 +13,11 @@ gpu_variant:
 # This could be done using extend_keys instead, with a change to the base cbc.yaml.
 # However there's currently a conda-forge bug that prevents this: https://github.com/conda/conda-build/issues/5048
 MACOSX_DEPLOYMENT_TARGET:    # [(osx and arm64)]
-  - 12.1                     # [(osx and arm64)]
-  - 12.1                     # [(osx and arm64)]
+  - 13.3                     # [(osx and arm64)]
+  - 13.3                     # [(osx and arm64)]
 CONDA_BUILD_SYSROOT:         # [(osx and arm64)]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk  # [(osx and arm64)]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk  # [(osx and arm64)]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [(osx and arm64)]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [(osx and arm64)]
 zip_keys:                    # [(osx and arm64)]
   - gpu_variant              # [(osx and arm64)]
   - MACOSX_DEPLOYMENT_TARGET # [(osx and arm64)]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,10 +2,12 @@ c_compiler_version:          # [(osx and arm64)]
   - 17                       # [(osx and arm64)]
 cxx_compiler_version:        # [(osx and arm64)]
   - 17                       # [(osx and arm64)]
+cuda_compiler_version:       # [((linux or win) and x86_64)]
+  - 12.8                     # [((linux or win) and x86_64)]
 gpu_variant:
   - cpu
   - metal                    # [(osx and arm64)]
-  #- cuda                     # [((linux or win) and x86_64)]
+  - cuda                     # [((linux or win) and x86_64)]
 # CONDA_BUILD_SYSROOT is defined in the base cbc.yaml, but it's reflected here so we can zip the keys and
 # build GPU and CPU at the same time for osx-arm64. It'll need to be manually updated here if the base cbc is changed.
 # This could be done using extend_keys instead, with a change to the base cbc.yaml.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,18 +1,22 @@
+c_compiler_version:          # [(osx and arm64)]
+  - 17                       # [(osx and arm64)]
+cxx_compiler_version:        # [(osx and arm64)]
+  - 17                       # [(osx and arm64)]
 gpu_variant:
   - cpu
   - metal                    # [(osx and arm64)]
-  #- cuda                     # [(linux and x86_64)]
+  #- cuda                     # [((linux or win) and x86_64)]
 # CONDA_BUILD_SYSROOT is defined in the base cbc.yaml, but it's reflected here so we can zip the keys and
 # build GPU and CPU at the same time for osx-arm64. It'll need to be manually updated here if the base cbc is changed.
 # This could be done using extend_keys instead, with a change to the base cbc.yaml.
 # However there's currently a conda-forge bug that prevents this: https://github.com/conda/conda-build/issues/5048
-MACOSX_SDK_VERSION:          # [(osx and arm64)]
-  - 11.1                     # [(osx and arm64)]
-  - 13.3                     # [(osx and arm64)]
+MACOSX_DEPLOYMENT_TARGET:    # [(osx and arm64)]
+  - 12.1                     # [(osx and arm64)]
+  - 12.1                     # [(osx and arm64)]
 CONDA_BUILD_SYSROOT:         # [(osx and arm64)]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [(osx and arm64)]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [(osx and arm64)]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk  # [(osx and arm64)]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk  # [(osx and arm64)]
 zip_keys:                    # [(osx and arm64)]
   - gpu_variant              # [(osx and arm64)]
-  - MACOSX_SDK_VERSION       # [(osx and arm64)]
+  - MACOSX_DEPLOYMENT_TARGET # [(osx and arm64)]
   - CONDA_BUILD_SYSROOT      # [(osx and arm64)]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -22,5 +22,3 @@ zip_keys:                    # [(osx and arm64)]
   - gpu_variant              # [(osx and arm64)]
   - MACOSX_DEPLOYMENT_TARGET # [(osx and arm64)]
   - CONDA_BUILD_SYSROOT      # [(osx and arm64)]
-python:
-  - 3.12

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -22,3 +22,5 @@ zip_keys:                    # [(osx and arm64)]
   - gpu_variant              # [(osx and arm64)]
   - MACOSX_DEPLOYMENT_TARGET # [(osx and arm64)]
   - CONDA_BUILD_SYSROOT      # [(osx and arm64)]
+python:
+  - 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,8 @@ build:
   # no CUDA-enabled pytorch on aarch yet
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
   # Python 3.14 support is introduced in v0.29, see https://github.com/pytorch/vision#installation
-  skip: true  # [not linux or not py312]
+  skip: true  # [not linux]
+  skip: true  # [py!=312]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,6 @@ source:
     - patches/0001-Use-system-giflib.patch
     - patches/0002-Force-nvjpeg-and-force-failure.patch
     - patches/0003-dont-test-for-turbo-jpeg.patch
-    # https://github.com/pytorch/vision/pull/8618
-    #- patches/0004-Fix-adjust_hue-on-ARM.patch
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
     - patches/0006-explicitly-configure-mps.patch
     - patches/0007-numpy-2-compatibility-in-test.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ build:
   script_env:
     # required by the setup.py script to find the right version in 0.20.1
     - BUILD_VERSION={{ version }}
+    - CUDA_HOME={{ PREFIX }}                 # [gpu_variant == "cuda"]
   # no CUDA-enabled pytorch on aarch yet -- 2.8?
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
   # libtorch built for py313

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ source:
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
     - patches/0006-explicitly-configure-mps.patch
     - patches/0007-numpy-2-compatibility-in-dataset.patch
-    - patches/0008-ffmpeg-keyframe.patch # [not win]
+    - patches/0008-ffmpeg-keyframe.patch # [linux]
 
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
     #- patches/0004-Fix-adjust_hue-on-ARM.patch
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
     - patches/0006-explicitly-configure-mps.patch
-    - patches/0007-numpy-2-compatibility-in-dataset.patch
+    - patches/0007-numpy-2-compatibility-in-test.patch
 
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
@@ -41,7 +41,6 @@ build:
   script_env:
     # required by the setup.py script to find the right version in 0.20.1
     - BUILD_VERSION={{ version }}
-    - CUDA_HOME={{ PREFIX }}                 # [gpu_variant == "cuda"]
   # no CUDA-enabled pytorch on aarch yet -- 2.8?
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
   # libtorch built for py313
@@ -83,18 +82,14 @@ requirements:
     # ffmpeg is detected at buildtime in setup.py, so no build.sh/bld.bat additions required to handle this
     - ffmpeg {{ ffmpeg }}  # [linux and (py!=39)]
     - pillow >=5.3.0,!=8.3.*
-    # - libtorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
-    - pytorch ={{ compatible_pytorch }}.*=*cuda*          # [gpu_variant == "cuda"]
-    - pytorch ={{ compatible_pytorch }}.*=*cpu*           # [gpu_variant == "cpu"]
-    - pytorch ={{ compatible_pytorch }}.*=*mps*           # [gpu_variant == "metal"]
+    - libtorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
+    - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
     # pybind11 2.13 has py314 support
     - pybind11 2.12
     - requests
   run:
     - python
-    - pytorch ={{ compatible_pytorch }}.*=*cuda*          # [gpu_variant == "cuda"]
-    - pytorch ={{ compatible_pytorch }}.*=*cpu*           # [gpu_variant == "cpu"]
-    - pytorch ={{ compatible_pytorch }}.*=*mps*           # [gpu_variant == "metal"]
+    - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
     - {{ pin_compatible('cudnn') }}          # [gpu_variant == "cuda"]
     - pillow >=5.3.0,!=8.3.*
     # They don't really document it, but it seems that they want a minimum version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,8 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ compiler('cuda') }}                 # [gpu_variant == "cuda"]
+    - {{ compiler('cuda') }}                   # [gpu_variant == "cuda"]
+    - cuda-version {{ cuda_compiler_version }} # [gpu_variant == "cuda"]
     - libcublas-dev                          # [build_platform != target_platform and gpu_variant == "cuda"]
     - libcusolver-dev                        # [build_platform != target_platform and gpu_variant == "cuda"]
     - libcusparse-dev                        # [build_platform != target_platform and gpu_variant == "cuda"]
@@ -60,6 +61,7 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - cuda-version {{ cuda_compiler_version }}   # [gpu_variant == "cuda"]
     - cudnn                                      # [gpu_variant == "cuda"]
     - libcublas-dev                              # [gpu_variant == "cuda"]
     - libcusolver-dev                            # [gpu_variant == "cuda"]
@@ -89,7 +91,6 @@ requirements:
     # They don't really document it, but it seems that they want a minimum version
     # https://github.com/pytorch/vision/blob/v0.19.0/packaging/torchvision/meta.yaml#L26
     - numpy >=1.23.5
-    - __cuda                                  # [gpu_variant == "cuda"]
     # On macOS, the GPU accelerated backend, MPS, can be used from macOS v12.3. This isn't tightly dependent on the
     # SDK version used.
     - __osx >=12.3                            # [gpu_variant == "metal"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ source:
     #- patches/0004-Fix-adjust_hue-on-ARM.patch
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
     - patches/0006-explicitly-configure-mps.patch
+    - patches/0007-numpy-2-compatibility-in-test.patch
 
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,6 +64,7 @@ requirements:
     - setuptools
     - wheel
     - cuda-version {{ cuda_compiler_version }}   # [gpu_variant == "cuda"]
+    - libcusparse-dev                            # [gpu_variant == "cuda"]
     - libnvjpeg-dev                              # [gpu_variant == "cuda"]
     - cuda-cudart-dev                            # [gpu_variant == "cuda"]
     # split off image/video into separate outputs?

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ requirements:
     # ffmpeg is detected at buildtime in setup.py, so no build.sh/bld.bat additions required to handle this
     - ffmpeg {{ ffmpeg }}  # [linux and (py!=39)]
     - pillow >=5.3.0,!=8.3.*
-    - libtorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
+    # - libtorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
     - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
     # pybind11 2.13 has py314 support
     - pybind11 2.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ requirements:
     # split off image/video into separate outputs?
     - jpeg {{ jpeg }}
     - libpng {{ libpng }}
-    - libwebp {{ libwebp }}
+    - libwebp {{ libwebp_base }}
     # https://github.com/pytorch/vision/pull/8406/files#r1730151047
     - giflib
     # ffmpeg only supported on linux, and also unsupported on python 3.9: https://github.com/pytorch/vision/blob/v0.20.1/setup.py#L371

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ build:
   # no CUDA-enabled pytorch on aarch yet
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
   # Python 3.14 support is introduced in v0.29, see https://github.com/pytorch/vision#installation
-  skip: true  # [py>313 or not linux or not py312]
+  skip: true  # [not linux or not py312]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,9 +41,6 @@ build:
     - BUILD_VERSION={{ version }}
   # no CUDA-enabled pytorch on aarch yet
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
-  # Python 3.14 support is introduced in v0.29, see https://github.com/pytorch/vision#installation
-  skip: true  # [not linux]
-  skip: true  # [py!=312]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }}                 # [gpu_variant == "cuda"]
@@ -78,11 +79,12 @@ requirements:
     - giflib
     # ffmpeg only supported on linux, and also unsupported on python 3.9: https://github.com/pytorch/vision/blob/v0.20.1/setup.py#L371
     # ffmpeg is detected at buildtime in setup.py, so no build.sh/bld.bat additions required to handle this
-    - ffmpeg 6.1.1 # [linux and (py!=39)]
+    - ffmpeg {{ ffmpeg }}  # [linux and (py!=39)]
     - pillow >=5.3.0,!=8.3.*
     - libtorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
     - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
-    - pybind11
+    # pybind11 2.13 has py314 support
+    - pybind11 2.12
     - requests
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ source:
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
     - patches/0006-explicitly-configure-mps.patch
     - patches/0007-numpy-2-compatibility-in-dataset.patch
+    - patches/0008-ffmpeg-keyframe.patch # [not win]
 
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
@@ -72,7 +73,7 @@ requirements:
     # split off image/video into separate outputs?
     - jpeg {{ jpeg }}
     - libpng {{ libpng }}
-    - libwebp {{ libwebp_base }}
+    - libwebp {{ libwebp }}
     # https://github.com/pytorch/vision/pull/8406/files#r1730151047
     - giflib
     # ffmpeg only supported on linux, and also unsupported on python 3.9: https://github.com/pytorch/vision/blob/v0.20.1/setup.py#L371

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,10 +64,6 @@ requirements:
     - setuptools
     - wheel
     - cuda-version {{ cuda_compiler_version }}   # [gpu_variant == "cuda"]
-    - cudnn                                      # [gpu_variant == "cuda"]
-    - libcublas-dev                              # [gpu_variant == "cuda"]
-    - libcusolver-dev                            # [gpu_variant == "cuda"]
-    - libcusparse-dev                            # [gpu_variant == "cuda"]
     - libnvjpeg-dev                              # [gpu_variant == "cuda"]
     - cuda-cudart-dev                            # [gpu_variant == "cuda"]
     # split off image/video into separate outputs?
@@ -88,14 +84,7 @@ requirements:
   run:
     - python
     - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
-    - {{ pin_compatible('cudnn') }}          # [gpu_variant == "cuda"]
     - pillow >=5.3.0,!=8.3.*
-    # They don't really document it, but it seems that they want a minimum version
-    # https://github.com/pytorch/vision/blob/v0.19.0/packaging/torchvision/meta.yaml#L26
-    - numpy >=1.23.5
-    # On macOS, the GPU accelerated backend, MPS, can be used from macOS v12.3. This isn't tightly dependent on the
-    # SDK version used.
-    - __osx >=12.3                            # [gpu_variant == "metal"]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,14 +84,17 @@ requirements:
     - ffmpeg {{ ffmpeg }}  # [linux and (py!=39)]
     - pillow >=5.3.0,!=8.3.*
     # - libtorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
-    # - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
-    - pytorch ={{ compatible_pytorch }}.*=*cpu*
+    - pytorch ={{ compatible_pytorch }}.*=*cuda*          # [gpu_variant == "cuda"]
+    - pytorch ={{ compatible_pytorch }}.*=*cpu*           # [gpu_variant == "cpu"]
+    - pytorch ={{ compatible_pytorch }}.*=*mps*           # [gpu_variant == "metal"]
     # pybind11 2.13 has py314 support
     - pybind11 2.12
     - requests
   run:
     - python
-    - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
+    - pytorch ={{ compatible_pytorch }}.*=*cuda*          # [gpu_variant == "cuda"]
+    - pytorch ={{ compatible_pytorch }}.*=*cpu*           # [gpu_variant == "cpu"]
+    - pytorch ={{ compatible_pytorch }}.*=*mps*           # [gpu_variant == "metal"]
     - {{ pin_compatible('cudnn') }}          # [gpu_variant == "cuda"]
     - pillow >=5.3.0,!=8.3.*
     # They don't really document it, but it seems that they want a minimum version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ build:
     - BUILD_VERSION={{ version }}
   # no CUDA-enabled pytorch on aarch yet
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
-  skip: true  # [osx]
+  skip: true  # [not win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ build:
     - BUILD_VERSION={{ version }}
   # no CUDA-enabled pytorch on aarch yet
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
-  skip: true  # [not linux]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,10 +41,8 @@ build:
     - BUILD_VERSION={{ version }}
   # no CUDA-enabled pytorch on aarch yet
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
-  # libtorch built for py313
-  skip: true  # [gpu_variant == "metal" and py!=313]
   # Python 3.14 support is introduced in v0.29, see https://github.com/pytorch/vision#installation
-  skip: true  # [py>313]
+  skip: true  # [py>313 or not linux]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,8 @@ requirements:
     - ffmpeg {{ ffmpeg }}  # [linux and (py!=39)]
     - pillow >=5.3.0,!=8.3.*
     # - libtorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
-    - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
+    # - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
+    - pytorch ={{ compatible_pytorch }}.*=*cpu*
     # pybind11 2.13 has py314 support
     - pybind11 2.12
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ build:
     - BUILD_VERSION={{ version }}
   # no CUDA-enabled pytorch on aarch yet
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
+  skip: true  # [not linux]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ build:
   script_env:
     # required by the setup.py script to find the right version in 0.20.1
     - BUILD_VERSION={{ version }}
-  # no CUDA-enabled pytorch on aarch yet -- 2.8?
+  # no CUDA-enabled pytorch on aarch yet
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
   # libtorch built for py313
   skip: true  # [gpu_variant == "metal" and py!=313]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,7 @@ requirements:
     # split off image/video into separate outputs?
     - jpeg {{ jpeg }}
     - libpng {{ libpng }}
-    - libwebp {{ libwebp }}
+    - libwebp >=1.6.0,<2.0a0 
     # https://github.com/pytorch/vision/pull/8406/files#r1730151047
     - giflib
     # ffmpeg only supported on linux, and also unsupported on python 3.9: https://github.com/pytorch/vision/blob/v0.20.1/setup.py#L371

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
     #- patches/0004-Fix-adjust_hue-on-ARM.patch
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
     - patches/0006-explicitly-configure-mps.patch
-    - patches/0007-numpy-2-compatibility-in-test.patch
+    - patches/0007-numpy-2-compatibility-in-dataset.patch
 
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ build:
     - BUILD_VERSION={{ version }}
   # no CUDA-enabled pytorch on aarch yet
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
+  skip: true  # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ build:
   # no CUDA-enabled pytorch on aarch yet
   skip: true  # [gpu_variant == "cuda" and (not x86_64)]
   # Python 3.14 support is introduced in v0.29, see https://github.com/pytorch/vision#installation
-  skip: true  # [py>313 or not linux]
+  skip: true  # [py>313 or not linux or not py312]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
-{% set version = "0.20.1" %}
+{% set version = "0.22.1" %}
 # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
 # torchvision requires that CUDA major and minor versions match with pytorch
 # https://github.com/pytorch/vision/blob/fa99a5360fbcd1683311d57a76fcc0e7323a4c1e/torchvision/extension.py#L79C1-L85C1
 {% set torch_proc_type = "cuda" ~ cuda_compiler_version | replace('.', '') if gpu_variant == "cuda" else "mps" if gpu_variant == "metal" else "cpu" %}
 # Upstream has specific compatability ranges for pytorch and python which are
 # updated every 0.x release. https://github.com/pytorch/vision#installation
-{% set compatible_pytorch = "2.5" %}
+{% set compatible_pytorch = "2.7" %}
 
-{% set build = 2 %}
+{% set build = 0 %}
 # Use a higher build number for the GPU variants, to ensure that they're
 # preferred by conda's solver, and they're preferentially
 # installed where the platform supports it.
@@ -21,14 +21,14 @@ package:
 
 source:
   url: https://github.com/pytorch/vision/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7e08c7f56e2c89859310e53d898f72bccc4987cd83e08cfd6303513da15a9e71
+  sha256: fa1b0a58e13c08329bcff8d52607b4e25944fd074c01dee1b501c8158fadcdec
   patches:
     # https://github.com/pytorch/vision/pull/8406/files#r1730151047
     - patches/0001-Use-system-giflib.patch
     - patches/0002-Force-nvjpeg-and-force-failure.patch
     - patches/0003-dont-test-for-turbo-jpeg.patch
     # https://github.com/pytorch/vision/pull/8618
-    - patches/0004-Fix-adjust_hue-on-ARM.patch
+    #- patches/0004-Fix-adjust_hue-on-ARM.patch
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
     - patches/0006-explicitly-configure-mps.patch
 
@@ -40,11 +40,12 @@ build:
   script_env:
     # required by the setup.py script to find the right version in 0.20.1
     - BUILD_VERSION={{ version }}
-  skip: true  # [s390x]
-  # no CUDA-enabled pytorch on aarch yet
-  skip: true  # [gpu_variant == "cuda" and aarch64]
-  # Python 3.13 support will be introduced in v 0.21, see here https://github.com/pytorch/vision/issues/8730#issuecomment-2504291914
-  skip: true  # [py>=313]
+  # no CUDA-enabled pytorch on aarch yet -- 2.8?
+  skip: true  # [gpu_variant == "cuda" and (not x86_64)]
+  # libtorch built for py313
+  skip: true  # [gpu_variant == "metal" and py!=313]
+  # Python 3.14 support is introduced in v0.29, see https://github.com/pytorch/vision#installation
+  skip: true  # [py>313]
 
 requirements:
   build:
@@ -78,8 +79,7 @@ requirements:
     # ffmpeg only supported on linux, and also unsupported on python 3.9: https://github.com/pytorch/vision/blob/v0.20.1/setup.py#L371
     # ffmpeg is detected at buildtime in setup.py, so no build.sh/bld.bat additions required to handle this
     - ffmpeg 6.1.1 # [linux and (py!=39)]
-    # exclude 8.3.0 and 8.3.1 specifically due to pytorch/vision#4146, python-pillow/Pillow#5571
-    - pillow >=5.3.0,!=8.3.0,!=8.3.1
+    - pillow >=5.3.0,!=8.3.*
     - libtorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
     - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
     - pybind11
@@ -88,7 +88,7 @@ requirements:
     - python
     - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
     - {{ pin_compatible('cudnn') }}          # [gpu_variant == "cuda"]
-    - pillow >=5.3.0,!=8.3.0,!=8.3.1
+    - pillow >=5.3.0,!=8.3.*
     # They don't really document it, but it seems that they want a minimum version
     # https://github.com/pytorch/vision/blob/v0.19.0/packaging/torchvision/meta.yaml#L26
     - numpy >=1.23.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0003-dont-test-for-turbo-jpeg.patch
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
     - patches/0006-explicitly-configure-mps.patch
-    - patches/0007-numpy-2-compatibility-in-test.patch
+    # - patches/0007-numpy-2-compatibility-in-test.patch
 
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0003-dont-test-for-turbo-jpeg.patch
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
     - patches/0006-explicitly-configure-mps.patch
-    # - patches/0007-numpy-2-compatibility-in-test.patch
+    - patches/0007-numpy-2-compatibility-in-dataset.patch
 
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]

--- a/recipe/patches/0007-numpy-2-compatibility-in-dataset.patch
+++ b/recipe/patches/0007-numpy-2-compatibility-in-dataset.patch
@@ -1,6 +1,17 @@
+From 3e29db30c4036bf80ae30fc6e3c49244dd54a6f6 Mon Sep 17 00:00:00 2001
+From: Jamie Robertson <jamierobertsongames@gmail.com>
+Date: Wed, 28 Jan 2026 11:48:26 +0000
+Subject: [PATCH] numpy 2 compatibility in test
+
+---
+ torchvision/datasets/_optical_flow.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/torchvision/datasets/_optical_flow.py b/torchvision/datasets/_optical_flow.py
+index 9ee4c4d..4e4588e 100644
 --- a/torchvision/datasets/_optical_flow.py
 +++ b/torchvision/datasets/_optical_flow.py
-@@ -536,8 +536,8 @@ def _read_flo(file_name: str) -> np.ndarray:
+@@ -503,8 +503,8 @@ def _read_flo(file_name: str) -> np.ndarray:
          if magic != b"PIEH":
              raise ValueError("Magic number incorrect. Invalid .flo file")
  
@@ -10,3 +21,7 @@
 +        h = int(np.fromfile(f, "<i4", count=1)[0])
          data = np.fromfile(f, "<f4", count=2 * w * h)
          return data.reshape(h, w, 2).transpose(2, 0, 1)
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/recipe/patches/0007-numpy-2-compatibility-in-dataset.patch
+++ b/recipe/patches/0007-numpy-2-compatibility-in-dataset.patch
@@ -1,14 +1,14 @@
-From 3e29db30c4036bf80ae30fc6e3c49244dd54a6f6 Mon Sep 17 00:00:00 2001
-From: Jamie Robertson <jamierobertsongames@gmail.com>
-Date: Wed, 28 Jan 2026 11:48:26 +0000
-Subject: [PATCH] numpy 2 compatibility in test
+From cb8b7bbb10eecdd022402dcc58b1345b4125a73e Mon Sep 17 00:00:00 2001
+From: Zhitao Yu <zycoding1@gmail.com>
+Date: Mon, 5 Jan 2026 11:17:07 -0800
+Subject: [PATCH] fix the datsset test failture
 
 ---
  torchvision/datasets/_optical_flow.py | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/torchvision/datasets/_optical_flow.py b/torchvision/datasets/_optical_flow.py
-index 9ee4c4d..4e4588e 100644
+index 52884dbc183..af8e17ad95c 100644
 --- a/torchvision/datasets/_optical_flow.py
 +++ b/torchvision/datasets/_optical_flow.py
 @@ -503,8 +503,8 @@ def _read_flo(file_name: str) -> np.ndarray:
@@ -17,11 +17,8 @@ index 9ee4c4d..4e4588e 100644
  
 -        w = int(np.fromfile(f, "<i4", count=1))
 -        h = int(np.fromfile(f, "<i4", count=1))
-+        w = int(np.fromfile(f, "<i4", count=1)[0])
-+        h = int(np.fromfile(f, "<i4", count=1)[0])
++        w = np.fromfile(f, "<i4", count=1).item()
++        h = np.fromfile(f, "<i4", count=1).item()
          data = np.fromfile(f, "<f4", count=2 * w * h)
          return data.reshape(h, w, 2).transpose(2, 0, 1)
  
--- 
-2.50.1 (Apple Git-155)
-

--- a/recipe/patches/0007-numpy-2-compatibility-in-dataset.patch
+++ b/recipe/patches/0007-numpy-2-compatibility-in-dataset.patch
@@ -1,0 +1,12 @@
+--- a/torchvision/datasets/_optical_flow.py
++++ b/torchvision/datasets/_optical_flow.py
+@@ -536,8 +536,8 @@ def _read_flo(file_name: str) -> np.ndarray:
+         if magic != b"PIEH":
+             raise ValueError("Magic number incorrect. Invalid .flo file")
+ 
+-        w = int(np.fromfile(f, "<i4", count=1))
+-        h = int(np.fromfile(f, "<i4", count=1))
++        w = int(np.fromfile(f, "<i4", count=1)[0])
++        h = int(np.fromfile(f, "<i4", count=1)[0])
+         data = np.fromfile(f, "<f4", count=2 * w * h)
+         return data.reshape(h, w, 2).transpose(2, 0, 1)

--- a/recipe/patches/0008-ffmpeg-keyframe.patch
+++ b/recipe/patches/0008-ffmpeg-keyframe.patch
@@ -1,0 +1,13 @@
+diff --git a/torchvision/csrc/io/decoder/video_stream.cpp b/torchvision/csrc/io/decoder/video_stream.cpp
+index fa08c65cac..bce5d3251f 100644
+--- a/torchvision/csrc/io/decoder/video_stream.cpp
++++ b/torchvision/csrc/io/decoder/video_stream.cpp
+@@ -122,7 +122,7 @@ int VideoStream::copyFrameBytes(ByteStorage* out, bool flush) {
+ void VideoStream::setHeader(DecoderHeader* header, bool flush) {
+   Stream::setHeader(header, flush);
+   if (!flush) { // no frames for video flush
+-    header->keyFrame = frame_->key_frame;
++    header->keyFrame = (frame_->flags & AV_FRAME_FLAG_KEY) != 0;
+     header->fps = av_q2d(av_guess_frame_rate(
+         inputCtx_, inputCtx_->streams[format_.stream], nullptr));
+   }


### PR DESCRIPTION
torchvision 0.22.1 

**Destination channel:** Defaults

### Links

- [PKG-6499]
- dev_url:        https://github.com/pytorch/vision
- conda_forge:    https://github.com/conda-forge/torchvision-feedstock
- pypi:           https://pypi.org/project/torchvision/0.22.1
- pypi inspector: https://inspector.pypi.io/project/torchvision/0.22.1

### Explanation of changes:

- new version number
- `clang 17` otherwise a complaint about redefining things
- `osx-arm64` `gpu` variant limited to `py313` because `libtorch` is dependent on `python_abi 3.13 *_cp313`


[PKG-6499]: https://anaconda.atlassian.net/browse/PKG-6499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ