### PR TITLE
Pin setuptools <82 (fix pkg_resources removal)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,8 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    # setup.py imports pkg_resources which was removed in setuptools 82+
+    - setuptools <82
     - wheel
     - cuda-version {{ cuda_compiler_version }}   # [gpu_variant == "cuda"]
     - libcublas-dev                              # [gpu_variant == "cuda"]


### PR DESCRIPTION
Hotfix for release graph failure on linux-aarch64 py3.12.

setup.py imports `pkg_resources` which was removed in setuptools 82.0.0 (Feb 2026).
The release graph fails with `ModuleNotFoundError: No module named 'pkg_resources'`.

Graph: https://package-build.anaconda.com/v1/graph/d6c010f4-e03e-4bc0-bda6-0744454050f6