### PR TITLE
Rebuild torchvision 0.25.0 — py3.14 only — CPU/MPS

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,8 @@ build:
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: mps_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "metal"]
   number: {{ build }}
-  # pytorch 2.10 has no py3.14 build on pkgs/main yet — skip until rebuilt
-  skip: true  # [py==314]
+  # py3.14 rebuild — only build py3.14 (py3.10–3.13 already shipped at build_number 0)
+  skip: true  # [py<314]
   script_env:
     # required by the setup.py script to find the right version in 0.20.1
     - BUILD_VERSION={{ version }}


### PR DESCRIPTION
torchvision 0.25.0

**Destination channel:** defaults

### Links

- [PKG-13212](https://anaconda.atlassian.net/browse/PKG-13212)
- [Upstream repository](https://github.com/pytorch/vision)
- [Upstream changelog/diff](https://github.com/pytorch/vision/releases/tag/v0.25.0)
- Relevant dependency PRs:
  - pytorch 2.10 py3.14: shipped to pkgs/main (2026-05)
  - Original py3.10–3.13 PRs: #31 (CPU/MPS), #32 (CUDA 12.8), #33 (CUDA 13.0)
  - CUDA 12.8 py3.14: #36
  - CUDA 13.0 py3.14: #37

### Explanation of changes:

- pytorch 2.10 py3.14 is now on pkgs/main; original PRs #31–33 shipped py3.10–3.13 only (blocked by missing pytorch py3.14 at release time)
- Flip `skip: true # [py==314]` → `skip: true # [py<314]` so this graph builds py3.14 only, leaving py3.10–3.13 artifacts at build_number 0 untouched
- Targets `master-cpu-py314` (dedicated landing branch) to avoid permanently tainting `master-cpu` with a `py<314` skip

[PKG-13212]: https://anaconda.atlassian.net/browse/PKG-13212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ