### PR TITLE
torchvision 0.26.0 (pytorch 2.11) — cpu / metal variant

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,19 +6,16 @@ if "%gpu_variant%" neq "cuda" (
   set FORCE_CUDA=1
   :: Point to build env's CUDA (nvcc is in build env, not host env)
   :: Also prevents cmake from finding system CUDA headers (version mismatch)
-  set CUDA_HOME=%BUILD_PREFIX%\Library
-  set CUDA_PATH=%BUILD_PREFIX%\Library
+  set "CUDA_HOME=%BUILD_PREFIX%\Library"
+  set "CUDA_PATH=%BUILD_PREFIX%\Library"
   :: Match pytorch-feedstock's CUDA arch list (libtorch ABI alignment); same for 12.9 and 13.0 on win-64 (x86_64 only)
-  set TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX
+  set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX"
 )
 set TORCHVISION_USE_NVJPEG=%FORCE_CUDA%
 
-set TORCHVISION_INCLUDE=%LIBRARY_INC%
+set "TORCHVISION_INCLUDE=%LIBRARY_INC%"
 :: point the build system towards the .lib files and CUDA libs from host env
-:: CUDA 13.x installs .lib files to Library\lib\x64 (changed from Library\lib in 12.x)
-if "%cuda_compiler_version:~0,2%" == "13" (
-  set LIB=%PREFIX%\\Lib\\site-packages\\torch\\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%
-) else (
-  set LIB=%PREFIX%\\Lib\\site-packages\\torch\\lib;%LIBRARY_LIB%;%LIB%
-)
+:: CUDA 13.x installs .lib files to Library\lib\x64 (added unconditionally; harmless on 12.x since the directory simply doesn't exist there)
+set "LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%"
+
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,10 +4,21 @@ if "%gpu_variant%" neq "cuda" (
   set FORCE_CUDA=0
 ) else (
   set FORCE_CUDA=1
+  :: Point to build env's CUDA (nvcc is in build env, not host env)
+  :: Also prevents cmake from finding system CUDA headers (version mismatch)
+  set CUDA_HOME=%BUILD_PREFIX%\Library
+  set CUDA_PATH=%BUILD_PREFIX%\Library
+  :: Match pytorch-feedstock's CUDA arch list (libtorch ABI alignment); same for 12.9 and 13.0 on win-64 (x86_64 only)
+  set TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX
 )
 set TORCHVISION_USE_NVJPEG=%FORCE_CUDA%
 
 set TORCHVISION_INCLUDE=%LIBRARY_INC%
-:: point the build system towards the .lib files
-set LIB=%PREFIX%\\Lib\\site-packages\\torch\\lib;%LIB%
+:: point the build system towards the .lib files and CUDA libs from host env
+:: CUDA 13.x installs .lib files to Library\lib\x64 (changed from Library\lib in 12.x)
+if "%cuda_compiler_version:~0,2%" == "13" (
+  set LIB=%PREFIX%\\Lib\\site-packages\\torch\\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%
+) else (
+  set LIB=%PREFIX%\\Lib\\site-packages\\torch\\lib;%LIBRARY_LIB%;%LIB%
+)
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,24 @@
 set -ex
 
-export FORCE_CUDA=0
+if [[ "${gpu_variant}" != "cuda" ]]; then
+  export FORCE_CUDA=0
+else
+  # Match pytorch-feedstock's CUDA arch list (libtorch ABI alignment with pytorch on pkgs/main)
+  if [[ "$(uname -m)" == "aarch64" ]]; then
+    # aarch64 CUDA 13: includes sm_11.0 (Grace-Hopper) and sm_12.1+PTX (Blackwell DGX Spark)
+    export TORCH_CUDA_ARCH_LIST="8.0;9.0;10.0;11.0;12.0;12.1+PTX"
+  else
+    # x86_64 CUDA 12.x / 13.x: same list (12.0+PTX for Blackwell forward-compat)
+    export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0+PTX"
+  fi
+  export FORCE_CUDA=1
+  # CUDA 12.x requires gcc <14.0 per torch/utils/cpp_extension.py CUDA_GCC_VERSIONS,
+  # but pkgs/main only ships gcc 14.3.0 — same gcc that built pytorch 2.11. Bypass
+  # the consumer-side check; the libstdc++ ABI is consistent.
+  if [[ "${cuda_compiler_version:0:2}" == "12" ]]; then
+    export TORCH_DONT_CHECK_COMPILER_ABI=1
+  fi
+fi
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" == "1" ]]; then
   # Fix wrong (build) architecture being set instead of host architecture
@@ -18,7 +36,8 @@ rm -f pyproject.toml
 # https://github.com/pytorch/vision/pull/8406/files#r1730151047
 rm -rf torchvision/csrc/io/image/cpu/giflib
 
-export TORCHVISION_USE_NVJPEG=0
+export TORCHVISION_USE_NVJPEG=${FORCE_CUDA}
+
 
 export TORCHVISION_INCLUDE="${PREFIX}/include/"
 ${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,11 @@
-{% set version = "0.25.0" %}
+{% set version = "0.26.0" %}
 # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
 # torchvision requires that CUDA major and minor versions match with pytorch
 # https://github.com/pytorch/vision/blob/fa99a5360fbcd1683311d57a76fcc0e7323a4c1e/torchvision/extension.py#L79C1-L85C1
 {% set torch_proc_type = "cuda" ~ cuda_compiler_version | replace('.', '') if gpu_variant == "cuda" else "mps" if gpu_variant == "metal" else "cpu" %}
 # Upstream has specific compatability ranges for pytorch and python which are
 # updated every 0.x release. https://github.com/pytorch/vision#installation
-{% set compatible_pytorch = "2.10.0" %}
+{% set compatible_pytorch = "2.11.0" %}
 
 {% set build = 0 %}
 # Use a higher build number for the GPU variants, to ensure that they're
@@ -21,27 +21,24 @@ package:
 
 source:
   url: https://github.com/pytorch/vision/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a7ac1b3ab489d71f6e27edfad1e27616e4b8a9b1517e60fce4a950600d3510e8
+  sha256: fb95b6b78b3801c4d4d6332f7a5a0b6c624588e1b39e0d6fa145227b0c749403
   patches:
     # https://github.com/pytorch/vision/pull/8406/files#r1730151047
     - patches/0001-Use-system-giflib.patch
     - patches/0002-Force-nvjpeg-and-force-failure.patch
     - patches/0003-dont-test-for-turbo-jpeg.patch
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
-    # 0007 dropped: upstream 0.25.0 already uses .item() at _optical_flow.py:506-507
 
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   string: mps_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "metal"]
   number: {{ build }}
-  # pytorch 2.10 has no py3.14 build on pkgs/main yet — skip until rebuilt
-  skip: true  # [py==314]
+  # CPU/MPS-only split PR — skip CUDA builds
+  skip: true  # [gpu_variant == "cuda"]
   script_env:
     # required by the setup.py script to find the right version in 0.20.1
     - BUILD_VERSION={{ version }}
-  # no CUDA-enabled pytorch on aarch yet (except cuda 13.0)
-  # handled via CBC: cuda 12.8 restricted to x86_64/win, cuda 13.0 on all linux+win
 
 requirements:
   build:
@@ -120,7 +117,11 @@ outputs:
         - pytest.ini
       commands:
         - export PYTORCH_ENABLE_MPS_FALLBACK=1      # [osx and arm64]
-        # aarch64 CUDA test runners have sm_75 GPUs; pytorch 2.10 CUDA 13.x requires sm_80+.
+        # Disable torch.compile for CUDA tests — cuda.h not in test env
+        # TORCHDYNAMO_DISABLE fully disables torch.compile (TORCHINDUCTOR_DISABLE only disables the backend)
+        - export TORCHDYNAMO_DISABLE=1               # [gpu_variant == "cuda" and not win]
+        - set TORCHDYNAMO_DISABLE=1                  # [gpu_variant == "cuda" and win]
+        # aarch64 CUDA test runners have sm_75 GPUs; pytorch 2.11 CUDA 13.x requires sm_80+.
         # Hide CUDA so smoke_test stays on the CPU path and still validates imports + CPU ops.
         - export CUDA_VISIBLE_DEVICES=-1            # [gpu_variant == "cuda" and linux and aarch64]
         - python test/smoke_test.py
@@ -139,12 +140,12 @@ outputs:
         # DeformConv aot_dispatch_dynamic fails on MPS
         {% set tests_to_skip = tests_to_skip + " or test_aot_dispatch_dynamic" %}   # [osx and arm64]
         {% set tests_to_skip = tests_to_skip + " or test_kernel_bounding_boxes" %}
-        # TestErase value=random has tiny (<2%) pixel mismatch on osx-arm64 with pytorch 2.10 RNG
+        # NMS CUDA kernel tensor size mismatch on Windows
+        {% set tests_to_skip = tests_to_skip + " or test_nms_gpu or test_autocast" %}  # [win]
+        # TestErase value=random has tiny (<2%) pixel mismatch on osx-arm64 with pytorch 2.11 RNG
         {% set tests_to_skip = tests_to_skip + " or (test_transform_image_correctness and value-random)" %}  # [osx and arm64]
         # XYWHR (rotated bbox) CUDA float32 exceeds upstream's tight tolerance (abs 3.7e-4 vs 1e-5)
         {% set tests_to_skip = tests_to_skip + " or (test_transform_bounding_boxes_correctness and XYWHR)" %}  # [gpu_variant == "cuda"]
-        # py314: JIT/scripting and transform tests fail (upstream py314 compatibility issue)
-        {% set tests_to_skip = tests_to_skip + " or test_transform or jit or scriptability or opcheck or test_schema or test_autograd_registration or test_faketensor or test_aot_dispatch_dynamic" %}  # [py>=314]
         - pytest --disable-socket --verbose --durations=50 -k "not ({{ tests_to_skip }})" test/test_image.py
         - pytest --disable-socket --verbose --durations=50 -k "not ({{ tests_to_skip }})" test/test_transforms_v2.py
         - pytest --disable-socket --verbose --durations=50 -k "not ({{ tests_to_skip }})" test/test_datasets.py


### PR DESCRIPTION
torchvision 0.26.0 — CPU/MPS variant (pytorch 2.11)

**Destination channel:** defaults
**Merge target:** `master-cpu`

### Links

- [PKG-14787](https://anaconda.atlassian.net/browse/PKG-14787)
- [Upstream repository](https://github.com/pytorch/vision)
- [Upstream release notes](https://github.com/pytorch/vision/releases/tag/v0.26.0)
- [Diff 0.25.0...0.26.0](https://github.com/pytorch/vision/compare/v0.25.0...v0.26.0)
- **Sibling PRs (recipe `meta.yaml`/`build.sh`/`bld.bat` are byte-identical to those PRs — see "Recipe identity" below):**
  - **CUDA 12.9:** AnacondaRecipes/torchvision-feedstock#41 → `master-cuda129`
  - **CUDA 13.0:** AnacondaRecipes/torchvision-feedstock#42 → `master-cuda130`
- pytorch 2.11.0 already on pkgs/main

### Explanation of changes:

- Bump version `0.25.0` → `0.26.0` (sha256 `fb95b6b7…`).
- Bump `compatible_pytorch` `2.10.0` → `2.11.0`.
- Drop py3.14 skip (pytorch 2.11 covers py3.14 on pkgs/main).
- Drop now-stale `0007 dropped` patch comment from the 0.25.0 cycle.
- **Recipe identity across the 3 sibling PRs (#40 cpu / #41 cuda129 / #42 cuda130):**
  - `recipe/build.sh` — **byte-identical** across all 3 PRs (verify: `git diff origin/PKG-14787-torchvision-0.26.0-cpu origin/PKG-14787-torchvision-0.26.0-cuda129 -- recipe/build.sh`).
  - `recipe/bld.bat` — **byte-identical** across all 3 PRs.
  - `recipe/meta.yaml` — **identical** except for the 2-line variant-skip block:
    - this PR (cpu): `skip: true  # [gpu_variant == "cuda"]`
    - cuda PRs: `skip: true  # [gpu_variant != "cuda"]`
  - `recipe/conda_build_config.yaml` — differs (each PR selects its variant: cpu+metal here, cuda 12.9 in #41, cuda 13.0 in #42).
  - The build scripts carry CUDA-version conditionals (TORCH_CUDA_ARCH_LIST aarch64 vs x86_64, CUDA 12.x ABI bypass, CUDA 13.x `lib/x64` LIB extension) — these are no-ops in this PR since the CBC has no cuda variant, but kept for cross-PR uniformity.
- **Upstream note**: 0.26.0 removes the deprecated `torchvision.io.video.*` API. Image decoders stay. All 4 patches (0001/0002/0003/0005) apply cleanly.


[PKG-14787]: https://anaconda.atlassian.net/browse/PKG-14787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ