### PR TITLE
torchvision 0.26.0 (pytorch 2.11) — cuda 13.0 variant

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,13 +8,17 @@ if "%gpu_variant%" neq "cuda" (
   :: Also prevents cmake from finding system CUDA headers (version mismatch)
   set CUDA_HOME=%BUILD_PREFIX%\Library
   set CUDA_PATH=%BUILD_PREFIX%\Library
-  :: CUDA 13.x: dropped compute_50-61, min is 7.5 (Turing)
-  set TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;8.9;9.0;10.0;10.3;12.0;12.1+PTX
+  :: Match pytorch-feedstock's CUDA arch list (libtorch ABI alignment); same for 12.9 and 13.0 on win-64 (x86_64 only)
+  set TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX
 )
 set TORCHVISION_USE_NVJPEG=%FORCE_CUDA%
 
 set TORCHVISION_INCLUDE=%LIBRARY_INC%
 :: point the build system towards the .lib files and CUDA libs from host env
 :: CUDA 13.x installs .lib files to Library\lib\x64 (changed from Library\lib in 12.x)
-set LIB=%PREFIX%\\Lib\\site-packages\\torch\\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%
+if "%cuda_compiler_version:~0,2%" == "13" (
+  set LIB=%PREFIX%\\Lib\\site-packages\\torch\\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%
+) else (
+  set LIB=%PREFIX%\\Lib\\site-packages\\torch\\lib;%LIBRARY_LIB%;%LIB%
+)
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,19 +6,16 @@ if "%gpu_variant%" neq "cuda" (
   set FORCE_CUDA=1
   :: Point to build env's CUDA (nvcc is in build env, not host env)
   :: Also prevents cmake from finding system CUDA headers (version mismatch)
-  set CUDA_HOME=%BUILD_PREFIX%\Library
-  set CUDA_PATH=%BUILD_PREFIX%\Library
+  set "CUDA_HOME=%BUILD_PREFIX%\Library"
+  set "CUDA_PATH=%BUILD_PREFIX%\Library"
   :: Match pytorch-feedstock's CUDA arch list (libtorch ABI alignment); same for 12.9 and 13.0 on win-64 (x86_64 only)
-  set TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX
+  set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX"
 )
 set TORCHVISION_USE_NVJPEG=%FORCE_CUDA%
 
-set TORCHVISION_INCLUDE=%LIBRARY_INC%
+set "TORCHVISION_INCLUDE=%LIBRARY_INC%"
 :: point the build system towards the .lib files and CUDA libs from host env
-:: CUDA 13.x installs .lib files to Library\lib\x64 (changed from Library\lib in 12.x)
-if "%cuda_compiler_version:~0,2%" == "13" (
-  set LIB=%PREFIX%\\Lib\\site-packages\\torch\\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%
-) else (
-  set LIB=%PREFIX%\\Lib\\site-packages\\torch\\lib;%LIBRARY_LIB%;%LIB%
-)
+:: CUDA 13.x installs .lib files to Library\lib\x64 (added unconditionally; harmless on 12.x since the directory simply doesn't exist there)
+set "LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%"
+
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,10 +3,21 @@ set -ex
 if [[ "${gpu_variant}" != "cuda" ]]; then
   export FORCE_CUDA=0
 else
-  # CUDA 13.x: dropped compute_50-70 (Maxwell/Pascal/Volta), min is 7.5 (Turing)
-  export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;8.9;9.0;10.0;10.3;12.0;12.1+PTX"
-
+  # Match pytorch-feedstock's CUDA arch list (libtorch ABI alignment with pytorch on pkgs/main)
+  if [[ "$(uname -m)" == "aarch64" ]]; then
+    # aarch64 CUDA 13: includes sm_11.0 (Grace-Hopper) and sm_12.1+PTX (Blackwell DGX Spark)
+    export TORCH_CUDA_ARCH_LIST="8.0;9.0;10.0;11.0;12.0;12.1+PTX"
+  else
+    # x86_64 CUDA 12.x / 13.x: same list (12.0+PTX for Blackwell forward-compat)
+    export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0+PTX"
+  fi
   export FORCE_CUDA=1
+  # CUDA 12.x requires gcc <14.0 per torch/utils/cpp_extension.py CUDA_GCC_VERSIONS,
+  # but pkgs/main only ships gcc 14.3.0 — same gcc that built pytorch 2.11. Bypass
+  # the consumer-side check; the libstdc++ ABI is consistent.
+  if [[ "${cuda_compiler_version:0:2}" == "12" ]]; then
+    export TORCH_DONT_CHECK_COMPILER_ABI=1
+  fi
 fi
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" == "1" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,11 @@
-{% set version = "0.25.0" %}
+{% set version = "0.26.0" %}
 # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
 # torchvision requires that CUDA major and minor versions match with pytorch
 # https://github.com/pytorch/vision/blob/fa99a5360fbcd1683311d57a76fcc0e7323a4c1e/torchvision/extension.py#L79C1-L85C1
 {% set torch_proc_type = "cuda" ~ cuda_compiler_version | replace('.', '') if gpu_variant == "cuda" else "mps" if gpu_variant == "metal" else "cpu" %}
 # Upstream has specific compatability ranges for pytorch and python which are
 # updated every 0.x release. https://github.com/pytorch/vision#installation
-{% set compatible_pytorch = "2.10.0" %}
+{% set compatible_pytorch = "2.11.0" %}
 
 {% set build = 0 %}
 # Use a higher build number for the GPU variants, to ensure that they're
@@ -21,14 +21,13 @@ package:
 
 source:
   url: https://github.com/pytorch/vision/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a7ac1b3ab489d71f6e27edfad1e27616e4b8a9b1517e60fce4a950600d3510e8
+  sha256: fb95b6b78b3801c4d4d6332f7a5a0b6c624588e1b39e0d6fa145227b0c749403
   patches:
     # https://github.com/pytorch/vision/pull/8406/files#r1730151047
     - patches/0001-Use-system-giflib.patch
     - patches/0002-Force-nvjpeg-and-force-failure.patch
     - patches/0003-dont-test-for-turbo-jpeg.patch
     - patches/0005-use-correct-encode-jpeg-test-dir.patch
-    # 0007 dropped: upstream 0.25.0 already uses .item() at _optical_flow.py:506-507
 
 build:
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
@@ -37,8 +36,6 @@ build:
   number: {{ build }}
   # CUDA-only split PR — skip CPU/MPS builds (osx dummy variant for Jinja2 rendering)
   skip: true  # [gpu_variant != "cuda"]
-  # pytorch 2.10 has no py3.14 build on pkgs/main yet — skip until rebuilt
-  skip: true  # [py==314]
   script_env:
     # required by the setup.py script to find the right version in 0.20.1
     - BUILD_VERSION={{ version }}
@@ -124,7 +121,7 @@ outputs:
         # TORCHDYNAMO_DISABLE fully disables torch.compile (TORCHINDUCTOR_DISABLE only disables the backend)
         - export TORCHDYNAMO_DISABLE=1               # [gpu_variant == "cuda" and not win]
         - set TORCHDYNAMO_DISABLE=1                  # [gpu_variant == "cuda" and win]
-        # aarch64 CUDA test runners have sm_75 GPUs; pytorch 2.10 CUDA 13.x requires sm_80+.
+        # aarch64 CUDA test runners have sm_75 GPUs; pytorch 2.11 CUDA 13.x requires sm_80+.
         # Hide CUDA so smoke_test stays on the CPU path and still validates imports + CPU ops.
         - export CUDA_VISIBLE_DEVICES=-1            # [gpu_variant == "cuda" and linux and aarch64]
         - python test/smoke_test.py
@@ -145,12 +142,10 @@ outputs:
         {% set tests_to_skip = tests_to_skip + " or test_kernel_bounding_boxes" %}
         # NMS CUDA kernel tensor size mismatch on Windows
         {% set tests_to_skip = tests_to_skip + " or test_nms_gpu or test_autocast" %}  # [win]
-        # TestErase value=random has tiny (<2%) pixel mismatch on osx-arm64 with pytorch 2.10 RNG
+        # TestErase value=random has tiny (<2%) pixel mismatch on osx-arm64 with pytorch 2.11 RNG
         {% set tests_to_skip = tests_to_skip + " or (test_transform_image_correctness and value-random)" %}  # [osx and arm64]
         # XYWHR (rotated bbox) CUDA float32 exceeds upstream's tight tolerance (abs 3.7e-4 vs 1e-5)
         {% set tests_to_skip = tests_to_skip + " or (test_transform_bounding_boxes_correctness and XYWHR)" %}  # [gpu_variant == "cuda"]
-        # py314: JIT/scripting and transform tests fail (upstream py314 compatibility issue)
-        {% set tests_to_skip = tests_to_skip + " or test_transform or jit or scriptability or opcheck or test_schema or test_autograd_registration or test_faketensor or test_aot_dispatch_dynamic" %}  # [py>=314]
         - pytest --disable-socket --verbose --durations=50 -k "not ({{ tests_to_skip }})" test/test_image.py
         - pytest --disable-socket --verbose --durations=50 -k "not ({{ tests_to_skip }})" test/test_transforms_v2.py
         - pytest --disable-socket --verbose --durations=50 -k "not ({{ tests_to_skip }})" test/test_datasets.py


### PR DESCRIPTION
torchvision 0.26.0 — CUDA 13.0 variant (pytorch 2.11)

**Destination channel:** defaults
**Merge target:** `master-cuda130`

### Links

- [PKG-14787](https://anaconda.atlassian.net/browse/PKG-14787)
- [Upstream repository](https://github.com/pytorch/vision)
- [Upstream release notes](https://github.com/pytorch/vision/releases/tag/v0.26.0)
- [Diff 0.25.0...0.26.0](https://github.com/pytorch/vision/compare/v0.25.0...v0.26.0)
- **Sibling PRs (recipe `meta.yaml`/`build.sh`/`bld.bat` are byte-identical to those PRs — see "Recipe identity" below):**
  - **CPU/MPS:** AnacondaRecipes/torchvision-feedstock#40 → `master-cpu`
  - **CUDA 12.9:** AnacondaRecipes/torchvision-feedstock#41 → `master-cuda129`
- pytorch 2.11.0 `gpu_cuda130` already on pkgs/main (linux-64, linux-aarch64, win-64)

### Explanation of changes:

- Bump version `0.25.0` → `0.26.0` (sha256 `fb95b6b7…`).
- Bump `compatible_pytorch` `2.10.0` → `2.11.0`.
- Drop py3.14 skip (pytorch 2.11 covers py3.14 on pkgs/main).
- Drop now-stale `0007 dropped` patch comment from the 0.25.0 cycle.
- **Recipe identity across the 3 sibling PRs (#40 cpu / #41 cuda129 / #42 cuda130):**
  - `recipe/build.sh` — **byte-identical** across all 3 PRs.
  - `recipe/bld.bat` — **byte-identical** across all 3 PRs.
  - `recipe/meta.yaml` — **identical** to #41 (cuda129); only differs from #40 (cpu) by the 2-line variant-skip block:
    - cpu PR: `skip: true  # [gpu_variant == "cuda"]`
    - this PR (cuda PRs): `skip: true  # [gpu_variant != "cuda"]`
  - `recipe/conda_build_config.yaml` — differs (each PR selects its variant: cpu+metal in #40, cuda 12.9 in #41, cuda 13.0 here).
- **Build-script details (CUDA 13 specific bits in shared scripts):**
  - `TORCH_CUDA_ARCH_LIST` aligned with our pytorch-feedstock CUDA 13 list:
    - x86_64 (linux + win): `7.5;8.0;8.6;9.0;10.0;12.0+PTX`
    - aarch64: `8.0;9.0;10.0;11.0;12.0;12.1+PTX` (sm_11.0 Grace-Hopper, sm_12.1+PTX Blackwell DGX Spark)
  - `bld.bat` extends `LIB` with `%LIBRARY_PREFIX%\lib\x64` for CUDA 13 (NVIDIA moved .lib files there starting in CUDA 13; harmless on 12.x since the dir doesn't exist).
- **Upstream note**: 0.26.0 removes the deprecated `torchvision.io.video.*` API. All 4 patches (0001/0002/0003/0005) apply cleanly.


[PKG-14787]: https://anaconda.atlassian.net/browse/PKG-14787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ