### PR TITLE
PKG-14948: rebuild torchvision 0.26.0 (CUDA 12.9) against pybind11 3.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 # updated every 0.x release. https://github.com/pytorch/vision#installation
 {% set compatible_pytorch = "2.11.0" %}
 
-{% set build = 0 %}
+{% set build = 1 %}
 # Use a higher build number for the GPU variants, to ensure that they're
 # preferred by conda's solver, and they're preferentially
 # installed where the platform supports it.
@@ -75,7 +75,11 @@ requirements:
     - pillow >=5.3.0,!=8.3.*
     - libtorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
     - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*
-    - pybind11 2.13.6
+    # pybind11 itself not needed: upstream uses torch.utils.cpp_extension
+    # which bundles pybind11 headers via libtorch/pytorch host deps above.
+    # pybind11-abi propagates the run_export pin (==11) for cross-module
+    # ABI safety with the corresponding pytorch build.
+    - pybind11-abi
   run:
     - python
     - pytorch ={{ compatible_pytorch }}.*=*{{ torch_proc_type }}*


### PR DESCRIPTION
torchvision 0.26.0 (CUDA 12.9 variant)

**Destination channel:** Defaults
**Base branch:** `master-cuda129` (long-lived CUDA 12.9 release track, currently at 0.26.0)

### Links
- [PKG-14948](https://anaconda.atlassian.net/browse/PKG-14948)
- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) (parent epic)
- Sibling PRs: AnacondaRecipes/torchvision-feedstock#44 (cpu/mps), cuda130 (open)

### Explanation of changes:
Same as the CPU PR but on the cuda129 long-lived branch:
- **Build number 0 -> 1** (no source change).
- **Drop `pybind11 2.13.6` host pin** — vestigial. Upstream uses `torch.utils.cpp_extension` with bundled pybind11 headers via pytorch/libtorch.
- **Add `pybind11-abi` to host** — triggers run_export so artifact declares `pybind11-abi ==11`.
- **Scope:** CUDA 12.9 only (CPU/MPS variants skipped via `gpu_variant != cuda` skip on this branch).

[PKG-14948]: https://anaconda.atlassian.net/browse/PKG-14948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ